### PR TITLE
made the location function crash-resilient when Geo-location API call fails

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -50,8 +50,26 @@ impl OpenMeteo {
 
     pub async fn location(self, place_name: &str) -> Result<OpenMeteo, Box<dyn Error>> {
         let url = format!("https://geocode.maps.co/search?q={}", place_name);
-        let response = reqwest::get(url).await?.text().await?;
+
+        let response = reqwest::get(url).await?;
+
+        if response.status() != reqwest::StatusCode::OK {
+              return Err("Error getting city coordinates from geolocation".into());
+        }
+        let response = response.text().await?;
+
         let json: Value = serde_json::from_str(&response).expect("Couldn't parse coordinates using geocode, try using .coordinates() instead".into());
+
+        let vec_len: usize;
+
+        match json{
+            Value::Array(ref val) => vec_len = val.len(),
+            _ => vec_len = 0
+        }
+        if vec_len < 1 {
+           return Err("Error getting city coordinates. Geolocation did not return any coordinates".into());
+        }
+
         let (lat, lon) = 
             (json[0]["lat"].as_str().unwrap()
                 .parse::<f32>().unwrap(), 


### PR DESCRIPTION
The location function in query.rs sometimes falls over. 

This is as a result of a failure in the geolocation API, whether as a result of a negative response to the calling function or a return of null set of location coordinates.

This PR simply checks the HTTP response code and the returned coordinate set, to ensure that subsequent code works only with a validated(to an extent) response.

Related to issue: [issue1](https://github.com/attakaro/open-meteo-rust/issues/1)